### PR TITLE
Add modifier support for keybindings

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -212,9 +212,6 @@
 /proc/sortRecord(list/L, field = "name", order = 1)
 	return sortTim(L, order >= 0 ? /proc/cmp_records_asc : /proc/cmp_records_dsc, sortkey=field)
 
-//Specifically for keybind datums in a list.
-/proc/sortKeybindings(list/L, order = 1)
-	return sortTim(L, order >= 0 ? /proc/cmp_keybinding_asc : /proc/cmp_keybinding_dsc)
 
 //any value in a list
 /proc/sortList(list/L, cmp=/proc/cmp_text_asc)

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -22,12 +22,6 @@
 /proc/cmp_list_dsc(list/a, list/b, sortkey)
 	return sorttext(a[sortkey], b[sortkey])
 
-/proc/cmp_keybinding_asc(datum/keybinding/a, datum/keybinding/b)
-	return cmp_numeric_asc(a.weight, b.weight)
-
-/proc/cmp_keybinding_dsc(datum/keybinding/a, datum/keybinding/b)
-	return cmp_numeric_dsc(a.weight, b.weight)
-
 // Datum cmp with vars is always slower than a specialist cmp proc, use your judgement.
 /proc/cmp_datum_numeric_asc(datum/a, datum/b, variable)
 	return cmp_numeric_asc(a.vars[variable], b.vars[variable])

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -115,10 +115,10 @@ var/global/list/datum/poster/poster_designs = subtypesof(/datum/poster)
 		GLOB.keybindings_by_name[initial(instance.name)] = instance
 		if (!(initial(instance.key) in GLOB.keybinding_list_by_key))
 			GLOB.keybinding_list_by_key[initial(instance.key)] = list()
-		GLOB.keybinding_list_by_key[initial(instance.key)] += instance
+		GLOB.keybinding_list_by_key[initial(instance.key)] += instance.name
 	// Sort all the keybindings by their weight
 	for(var/key in GLOB.keybinding_list_by_key)
-		GLOB.keybinding_list_by_key[key] = sortKeybindings(GLOB.keybinding_list_by_key[key])
+		GLOB.keybinding_list_by_key[key] = sortList(GLOB.keybinding_list_by_key[key])
 
 	return TRUE
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -936,7 +936,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/clear_key = text2num(href_list["clear_key"])
 			var/old_key = href_list["old_key"]
 			if(clear_key)
-				message_admins("clear_key, old - [old_key], name [kb_name]")
 				if(old_key != "Unbound") // if it was already set
 					key_bindings[old_key] -= kb_name
 					key_bindings["Unbound"] += list(kb_name)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -11,13 +11,17 @@
 
 	// Client-level keybindings are ones anyone should be able to do at any time
 	// Things like taking screenshots, hitting tab, and adminhelps.
-	for (var/i in prefs.key_bindings[_key])
-		var/datum/keybinding/kb = i
+	var/AltMod = keys_held["Alt"] ? "Alt-" : ""
+	var/CtrlMod = keys_held["Ctrl"] ? "Ctrl-" : ""
+	var/ShiftMod = keys_held["Shift"] ? "Shift-" : ""
+	var/full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
+	for (var/kb_name in prefs.key_bindings[full_key])
+		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		if (kb.down(src))
 			break
 
-	holder?.key_down(_key, src)
-	mob.focus?.key_down(_key, src)
+	holder?.key_down(full_key, src)
+	mob.focus?.key_down(full_key, src)
 
 
 /client/verb/keyUp(_key as text)
@@ -29,8 +33,10 @@
 	if(!(next_move_dir_add & movement))
 		next_move_dir_sub |= movement
 
-	for (var/i in prefs.key_bindings[_key])
-		var/datum/keybinding/kb = i
+	// We don't do full key for release, because for mod keys you
+	// can hold different keys and releasing any should be handled by the key binding specifically
+	for (var/kb_name in prefs.key_bindings[_key])
+		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		if (kb.up(src))
 			break
 


### PR DESCRIPTION
## About The Pull Request

Fixes keybinds, and adds support for modifier keys: Alt, Ctrl, Shift.

## Changelog
:cl:
add: Support for modifiers in keybindings as well as expanding the range to include Home, End and the adjacent keys.
fix: keybindings not saving correctly
/:cl:
